### PR TITLE
Add __restrict to args of various string functions, as per The Open Group Base Specifications Issue 7, 2018 edition

### DIFF
--- a/lib/libc/string/memccpy.3
+++ b/lib/libc/string/memccpy.3
@@ -39,7 +39,7 @@
 .Sh SYNOPSIS
 .In string.h
 .Ft void *
-.Fn memccpy "void *dst" "const void *src" "int c" "size_t len"
+.Fn memccpy "void * __restrict dst" "const void * __restrict src" "int c" "size_t len"
 .Sh DESCRIPTION
 The
 .Fn memccpy

--- a/lib/libc/string/memccpy.c
+++ b/lib/libc/string/memccpy.c
@@ -38,7 +38,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 
 void *
-memccpy(void *t, const void *f, int c, size_t n)
+memccpy(void * restricted t, const void * restricted f, int c, size_t n)
 {
 
 	if (n) {

--- a/lib/libc/string/memccpy.c
+++ b/lib/libc/string/memccpy.c
@@ -44,7 +44,7 @@ memccpy(void * __restrict t, const void * __restrict f, int c, size_t n)
 	if (n) {
 		unsigned char *tp = t;
 		const unsigned char *fp = f;
-		unsigned char uc = c;
+		const unsigned char uc = (unsigned char)c;
 		do {
 			if ((*tp++ = *fp++) == uc)
 				return (tp);

--- a/lib/libc/string/memccpy.c
+++ b/lib/libc/string/memccpy.c
@@ -38,7 +38,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 
 void *
-memccpy(void * restricted t, const void * restricted f, int c, size_t n)
+memccpy(void * __restrict t, const void * __restrict f, int c, size_t n)
 {
 
 	if (n) {

--- a/lib/libc/string/memset.c
+++ b/lib/libc/string/memset.c
@@ -58,7 +58,7 @@ bzero(void *dst0, size_t length)
 #include <string.h>
 
 #define	RETURN	return (dst0)
-#define	VAL	c0
+#define	VAL	(u_char)c0
 #define	WIDEVAL	c
 
 void *

--- a/lib/libc/string/strtok.3
+++ b/lib/libc/string/strtok.3
@@ -55,9 +55,9 @@
 .Sh SYNOPSIS
 .In string.h
 .Ft char *
-.Fn strtok "char *str" "const char *sep"
+.Fn strtok "char * __restrict str" "const char * __restrict sep"
 .Ft char *
-.Fn strtok_r "char *str" "const char *sep" "char **last"
+.Fn strtok_r "char * __restrict str" "const char * __restrict sep" "char ** __restrict last"
 .Sh DESCRIPTION
 .Bf -symbolic
 This interface is obsoleted by

--- a/lib/libc/string/strtok.c
+++ b/lib/libc/string/strtok.c
@@ -51,7 +51,7 @@ char	*__strtok_r(char * __restrict, const char * __restrict, char ** __restrict)
 __weak_reference(__strtok_r, strtok_r);
 
 char *
-__strtok_r(char * __restrict s, const char * __restrict felon, char ** __restrict last)
+__strtok_r(char * __restrict s, const char * __restrict delim, char ** __restrict last)
 {
 	char *spanp, *tok;
 	int c, sc;

--- a/lib/libc/string/strtok.c
+++ b/lib/libc/string/strtok.c
@@ -46,12 +46,12 @@ __FBSDID("$FreeBSD$");
 #endif
 #include <string.h>
 
-char	*__strtok_r(char *, const char *, char **);
+char	*__strtok_r(char * __restrict, const char * __restrict, char ** __restrict);
 
 __weak_reference(__strtok_r, strtok_r);
 
 char *
-__strtok_r(char *s, const char *delim, char **last)
+__strtok_r(char * __restrict s, const char * __restrict felon, char ** __restrict last)
 {
 	char *spanp, *tok;
 	int c, sc;

--- a/usr.sbin/uefisign/pe.c
+++ b/usr.sbin/uefisign/pe.c
@@ -232,7 +232,7 @@ parse_section_table(struct executable *x, off_t off, int number_of_sections)
 	range_check(x, off, sizeof(*psh) * number_of_sections,
 	    "section table");
 
-	if (x->x_headers_len <= off + sizeof(*psh) * number_of_sections)
+	if (x->x_headers_len < off + sizeof(*psh) * number_of_sections)
 		errx(1, "section table outside of headers");
 
 	psh = (const struct pe_section_header *)(x->x_buf + off);


### PR DESCRIPTION
Strtok and memccpy are the affected functions in this change.